### PR TITLE
chore: rebrand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# sv-strip
+# @svecosystem/strip-types
 
 ## 0.2.1
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# sv-strip
+# @svecosystem/strip-types
 
 A type stripper for Svelte.
 
 ```sh
-pnpm install sv-strip
+pnpm install @svecosystem/strip-types
 ```
 
 ```ts
-import { strip } from 'sv-strip';
+import { strip } from '@svecosystem/strip-types';
 
 const ts = `<script lang="ts">
     let value = $state<string>('');
@@ -40,7 +40,7 @@ const js = strip(ts);
 
 ## Formatting
 
-By default `sv-strip` will remove leading and trailing whitespace when removing nodes. This will result in an output that is correctly formatted (with a small performance penalty).
+By default `@svecosystem/strip-types` will remove leading and trailing whitespace when removing nodes. This will result in an output that is correctly formatted (with a small performance penalty).
 
 If you are doing your own formatting you can disable this behavior with the `format` option like so:
 ```ts
@@ -60,7 +60,7 @@ const js = strip(ts, { removeEmptyScripts: false });
 
 ### Formatting
 
-While `sv-strip` includes a `format` option it is not a formatter. It will do it's best to maintain the formatting of the original code when stripping types but it is still recommended to use your own formatter if possible.
+While `@svecosystem/strip-types` includes a `format` option it is not a formatter. It will do it's best to maintain the formatting of the original code when stripping types but it is still recommended to use your own formatter if possible.
 
 ### Unsupported Syntax
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "sv-strip",
+	"name": "@svecosystem/strip-types",
 	"description": "A type stripper for Svelte.",
 	"version": "0.2.1",
 	"license": "MIT",
@@ -9,10 +9,10 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/ieedan/sv-strip.git"
+		"url": "git+https://github.com/svecosystem/strip-types.git"
 	},
 	"bugs": {
-		"url": "https://github.com/ieedan/sv-strip/issues"
+		"url": "https://github.com/svecosystem/strip-types/issues"
 	},
 	"keywords": [
 		"svelte",

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ export type Options = {
  * ## Usage
  * ```ts
  * import assert from 'node:assert';
- * import { strip } from 'sv-strip';
+ * import { strip } from '@svecosystem/strip-types';
  *
  * const source = `<script lang="ts">
  *      let value = $state<string>('');


### PR DESCRIPTION
Rename `sv-strip` to `svecosystem/strip-types`.

Also not sure if we want to change the versioning here so let me know @AdrianGonz97 