### PR TITLE
chore: ignore package.json in formatting

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -10,7 +10,7 @@
 		"attributePosition": "auto"
 	},
 	"files": {
-		"ignore": ["dist", "node_modules", "tests/cases"]
+		"ignore": ["dist", "node_modules", "tests/cases", "package.json"]
 	},
 	"organizeImports": { "enabled": true },
 	"linter": {


### PR DESCRIPTION
I don't want to have to do this but I wasn't able to figure out how to get the formatting to match up so this is just the solution for now.