### PR TITLE
chore: bump deps + prevent changeset format

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://unpkg.com/@changesets/config@3.0.2/schema.json",
+	"$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
 	"changelog": "@changesets/cli/changelog",
 	"commit": false,
 	"fixed": [],
@@ -7,5 +7,6 @@
 	"access": "public",
 	"baseBranch": "main",
 	"updateInternalDependencies": "patch",
-	"ignore": []
+	"ignore": [],
+	"prettier": false
 }

--- a/.changeset/sweet-plums-listen.md
+++ b/.changeset/sweet-plums-listen.md
@@ -1,0 +1,6 @@
+---
+"@svecosystem/strip-types": patch
+---
+
+chore: bump deps
+  

--- a/biome.json
+++ b/biome.json
@@ -10,7 +10,7 @@
 		"attributePosition": "auto"
 	},
 	"files": {
-		"ignore": ["dist", "node_modules", "tests/cases", "package.json"]
+		"ignore": ["dist", "node_modules", "tests/cases"]
 	},
 	"organizeImports": { "enabled": true },
 	"linter": {

--- a/package.json
+++ b/package.json
@@ -14,13 +14,7 @@
 	"bugs": {
 		"url": "https://github.com/svecosystem/strip-types/issues"
 	},
-	"keywords": [
-		"svelte",
-		"strip",
-		"types",
-		"typescript",
-		"javascript"
-	],
+	"keywords": ["svelte", "strip", "types", "typescript", "javascript"],
 	"packageManager": "pnpm@10.4.1",
 	"type": "module",
 	"scripts": {
@@ -32,9 +26,7 @@
 		"changeset": "changeset",
 		"ci:release": "unbuild && changeset publish"
 	},
-	"files": [
-		"dist"
-	],
+	"files": ["dist"],
 	"exports": {
 		".": {
 			"import": "./dist/index.mjs",
@@ -44,7 +36,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "1.9.4",
 		"@changesets/cli": "^2.27.8",
-		"@types/node": "^22.13.10",
+		"@types/node": "^22.13.13",
 		"unbuild": "^3.5.0",
 		"vitest": "^3.0.9"
 	},
@@ -52,6 +44,6 @@
 		"estree-walker": "^3.0.3",
 		"magic-string": "^0.30.17",
 		"pathe": "^2.0.3",
-		"svelte": "^5.23.2"
+		"svelte": "^5.25.3"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       svelte:
-        specifier: ^5.23.2
-        version: 5.23.2
+        specifier: ^5.25.3
+        version: 5.25.3
     devDependencies:
       '@biomejs/biome':
         specifier: 1.9.4
@@ -28,14 +28,14 @@ importers:
         specifier: ^2.27.8
         version: 2.28.1
       '@types/node':
-        specifier: ^22.13.10
-        version: 22.13.10
+        specifier: ^22.13.13
+        version: 22.13.13
       unbuild:
         specifier: ^3.5.0
         version: 3.5.0(typescript@5.8.2)
       vitest:
         specifier: ^3.0.9
-        version: 3.0.9(@types/node@22.13.10)
+        version: 3.0.9(@types/node@22.13.13)
 
 packages:
 
@@ -801,8 +801,8 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@22.13.10':
-    resolution: {integrity: sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==}
+  '@types/node@22.13.13':
+    resolution: {integrity: sha512-ClsL5nMwKaBRwPcCvH8E7+nU4GxHVx1axNvMZTFHMEfNI7oahimt26P5zjVCRrjiIWj6YFXfE1v3dEp94wLcGQ==}
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
@@ -1688,8 +1688,8 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  svelte@5.23.2:
-    resolution: {integrity: sha512-PHP1o0aYJNMatiZ+0nq1W/Z1W1/l5Z94B9nhMIo7gsuTBbxC454g4O5SQMjQpZBUZi5ANYUrXJOE4gPzcN/VQw==}
+  svelte@5.25.3:
+    resolution: {integrity: sha512-J9rcZ/xVJonAoESqVGHHZhrNdVbrCfkdB41BP6eiwHMoFShD9it3yZXApVYMHdGfCshBsZCKsajwJeBbS/M1zg==}
     engines: {node: '>=18'}
 
   svgo@3.3.2:
@@ -2421,7 +2421,7 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@22.13.10':
+  '@types/node@22.13.13':
     dependencies:
       undici-types: 6.20.0
 
@@ -2434,13 +2434,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.9(vite@5.4.14(@types/node@22.13.10))':
+  '@vitest/mocker@3.0.9(vite@5.4.14(@types/node@22.13.13))':
     dependencies:
       '@vitest/spy': 3.0.9
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 5.4.14(@types/node@22.13.10)
+      vite: 5.4.14(@types/node@22.13.13)
 
   '@vitest/pretty-format@3.0.9':
     dependencies:
@@ -3326,7 +3326,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte@5.23.2:
+  svelte@5.25.3:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -3435,13 +3435,13 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-node@3.0.9(@types/node@22.13.10):
+  vite-node@3.0.9(@types/node@22.13.13):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 5.4.14(@types/node@22.13.10)
+      vite: 5.4.14(@types/node@22.13.13)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -3453,19 +3453,19 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.14(@types/node@22.13.10):
+  vite@5.4.14(@types/node@22.13.13):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.3
       rollup: 4.35.0
     optionalDependencies:
-      '@types/node': 22.13.10
+      '@types/node': 22.13.13
       fsevents: 2.3.3
 
-  vitest@3.0.9(@types/node@22.13.10):
+  vitest@3.0.9(@types/node@22.13.13):
     dependencies:
       '@vitest/expect': 3.0.9
-      '@vitest/mocker': 3.0.9(vite@5.4.14(@types/node@22.13.10))
+      '@vitest/mocker': 3.0.9(vite@5.4.14(@types/node@22.13.13))
       '@vitest/pretty-format': 3.0.9
       '@vitest/runner': 3.0.9
       '@vitest/snapshot': 3.0.9
@@ -3481,11 +3481,11 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 5.4.14(@types/node@22.13.10)
-      vite-node: 3.0.9(@types/node@22.13.10)
+      vite: 5.4.14(@types/node@22.13.13)
+      vite-node: 3.0.9(@types/node@22.13.13)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.13.10
+      '@types/node': 22.13.13
     transitivePeerDependencies:
       - less
       - lightningcss


### PR DESCRIPTION
This should hopefully fix issues with different formatting between changesets and biome.

Also bumped `svelte`.